### PR TITLE
Fix leak in encode_gc()

### DIFF
--- a/c_src/erasure.c
+++ b/c_src/erasure.c
@@ -201,6 +201,9 @@ encode_gc(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
     }
     schedule = jerasure_smart_bitmatrix_to_schedule(k, m, w, bitmatrix);
     if (schedule == NULL) {
+        free(shards);
+        free(matrix);
+        free(bitmatrix);
         return enif_make_badarg(env);
     }
     jerasure_schedule_encode(k, m, w, schedule, data_ptrs, coding_ptrs, blocksize, blocksize/w);
@@ -221,6 +224,8 @@ encode_gc(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
     }
     free(shards);
     free(matrix);
+    free(bitmatrix);
+    jerasure_free_schedule(schedule);
     return enif_make_tuple2(env, enif_make_atom(env, "ok"), list);
 }
 
@@ -575,6 +580,9 @@ decode_gc(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 
 cleanup:
 
+        if (bitmatrix != NULL) {
+            free(bitmatrix);
+        }
         if (matrix != NULL) {
             free(matrix);
         }


### PR DESCRIPTION
Leak detected by address sanitizer (ASan).

## Current

```
$ LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so ./rebar3 as test do eunit,ct
===> Verifying dependencies...
===> Compiling erasure
make: Entering directory 'erlang-erasure/c_src'
make: 'erlang-erasure/c_src/../priv/erasure.so' is up to date.
make: Leaving directory 'erlang-erasure/c_src'
===> Getting log of git dependency failed in erlang-erasure. Falling back to version 0.0.0
===> Performing EUnit tests...

Finished in 0.021 seconds
0 tests
===> Verifying dependencies...
===> Compiling erasure
make: Entering directory 'erlang-erasure/c_src'
make: 'erlang-erasure/c_src/../priv/erasure.so' is up to date.
make: Leaving directory 'erlang-erasure/c_src'
===> Getting log of git dependency failed in erlang-erasure. Falling back to version 0.0.0
===> Running Common Test suites...
%%% erasure_SUITE: ...
All 3 tests passed.

=================================================================
==6315==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 19008 byte(s) in 3 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def88aad1 in jerasure_smart_bitmatrix_to_schedule erlang-erasure/c_src/jerasure/src/jerasure.c:1308
    #2 0x7f9def881c46 in encode_gc erlang-erasure/c_src/erasure.c:202
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

Direct leak of 9492 byte(s) in 3 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def883d88 in jerasure_matrix_to_bitmatrix erlang-erasure/c_src/jerasure/src/jerasure.c:285
    #2 0x7f9def881bb5 in encode_gc erlang-erasure/c_src/erasure.c:196
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

Indirect leak of 7560 byte(s) in 378 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def88b29a in jerasure_smart_bitmatrix_to_schedule erlang-erasure/c_src/jerasure/src/jerasure.c:1380
    #2 0x7f9def881c46 in encode_gc erlang-erasure/c_src/erasure.c:202
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

Indirect leak of 4800 byte(s) in 240 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def88ba74 in jerasure_smart_bitmatrix_to_schedule erlang-erasure/c_src/jerasure/src/jerasure.c:1403
    #2 0x7f9def881c46 in encode_gc erlang-erasure/c_src/erasure.c:202
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

Indirect leak of 360 byte(s) in 18 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def88b5b9 in jerasure_smart_bitmatrix_to_schedule erlang-erasure/c_src/jerasure/src/jerasure.c:1392
    #2 0x7f9def881c46 in encode_gc erlang-erasure/c_src/erasure.c:202
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

Indirect leak of 60 byte(s) in 3 object(s) allocated from:
    #0 0x7f9e3b239b40 in __interceptor_malloc (/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so+0xdeb40)
    #1 0x7f9def88c094 in jerasure_smart_bitmatrix_to_schedule erlang-erasure/c_src/jerasure/src/jerasure.c:1431
    #2 0x7f9def881c46 in encode_gc erlang-erasure/c_src/erasure.c:202
    #3 0x558cc3bc6d5a in erts_call_dirty_nif (/usr/lib/erlang/erts-10.3.1/bin/beam.smp+0x21dd5a)
    #4 0x7f9df49ac83f  (<unknown module>)

SUMMARY: AddressSanitizer: 41280 byte(s) leaked in 645 allocation(s).
```

## Fixed

```
$ LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so ./rebar3 as test do eunit,ct
===> Verifying dependencies...
===> Compiling erasure
make: Entering directory 'erlang-erasure/c_src'
make: 'erlang-erasure/c_src/../priv/erasure.so' is up to date.
make: Leaving directory 'erlang-erasure/c_src'
===> Getting log of git dependency failed in erlang-erasure. Falling back to version 0.0.0
===> Performing EUnit tests...
Finished in 0.021 seconds
0 tests
===> Verifying dependencies...
===> Compiling erasure
make: Entering directory 'erlang-erasure/c_src'
make: 'erlang-erasure/c_src/../priv/erasure.so' is up to date.
make: Leaving directory 'erlang-erasure/c_src'
===> Getting log of git dependency failed in erlang-erasure. Falling back to version 0.0.0
===> Running Common Test suites...
%%% erasure_SUITE: ...
All 3 tests passed.
```
