### PR TITLE
Don't invoke make directly; use CMAKE_BUILD_TOOL

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -12,6 +12,11 @@ include(ASan)
 IF (APPLE)
   set(CMAKE_MODULE_LINKER_FLAGS "-flat_namespace -undefined suppress")
   set(CMAKE_MACOSX_RPATH 1)
+  execute_process(COMMAND
+    xcrun --show-sdk-path
+    OUTPUT_VARIABLE APPLE_SDK_ROOT
+    )
+  set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
 ENDIF()
 
 #

--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -12,10 +12,14 @@ include(ASan)
 IF (APPLE)
   set(CMAKE_MODULE_LINKER_FLAGS "-flat_namespace -undefined suppress")
   set(CMAKE_MACOSX_RPATH 1)
-  execute_process(COMMAND
-    xcrun --show-sdk-path
-    OUTPUT_VARIABLE APPLE_SDK_ROOT
-    )
+  if (NOT DEFINED ENV{SDKROOT})
+    execute_process(COMMAND
+      xcrun --show-sdk-path
+      OUTPUT_VARIABLE APPLE_SDK_ROOT
+      )
+  else()
+     set(APPLE_SDK_ROOT $ENV{SDKROOT})
+  endif()
   set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
 ENDIF()
 

--- a/c_src/cmake/FindGFComplete.cmake
+++ b/c_src/cmake/FindGFComplete.cmake
@@ -5,6 +5,14 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
 endif()
 
+if (APPLE)
+  execute_process(COMMAND
+    xcrun --show-sdk-path
+    OUTPUT_VARIABLE APPLE_SDK_ROOT
+    )
+  set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
+endif()
+
 ExternalProject_Add(gf-complete
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/gf-complete
   GIT_REPOSITORY    https://github.com/ceph/gf-complete.git
@@ -19,7 +27,8 @@ ExternalProject_Add(gf-complete
                     $ENV{CONFIGURE_ARGS}
                     CC=${CMAKE_C_COMPILER}
                     CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
-  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j
+                    ${GF_APPLE_ENV}  
+  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j ${GF_APPLE_ENV}
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libgf_complete.a
   INSTALL_COMMAND   ${CMAKE_BUILD_TOOL} install
   )

--- a/c_src/cmake/FindGFComplete.cmake
+++ b/c_src/cmake/FindGFComplete.cmake
@@ -5,14 +5,6 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
 endif()
 
-if (APPLE)
-  execute_process(COMMAND
-    xcrun --show-sdk-path
-    OUTPUT_VARIABLE APPLE_SDK_ROOT
-    )
-  set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
-endif()
-
 ExternalProject_Add(gf-complete
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/gf-complete
   GIT_REPOSITORY    https://github.com/ceph/gf-complete.git

--- a/c_src/cmake/FindGFComplete.cmake
+++ b/c_src/cmake/FindGFComplete.cmake
@@ -19,9 +19,9 @@ ExternalProject_Add(gf-complete
                     $ENV{CONFIGURE_ARGS}
                     CC=${CMAKE_C_COMPILER}
                     CFLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
-  BUILD_COMMAND     make -j
+  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libgf_complete.a
-  INSTALL_COMMAND   make install
+  INSTALL_COMMAND   ${CMAKE_BUILD_TOOL} install
   )
 
 add_library(GFComplete::GFComplete STATIC IMPORTED)

--- a/c_src/cmake/FindJerasure.cmake
+++ b/c_src/cmake/FindJerasure.cmake
@@ -8,14 +8,6 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
 endif()
 
-if (APPLE)
-  execute_process(COMMAND
-    xcrun --show-sdk-path
-    OUTPUT_VARIABLE APPLE_SDK_ROOT
-    )
-  set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
-endif()
-
 ExternalProject_Add(jerasure
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/jerasure
   GIT_REPOSITORY    http://github.com/ceph/jerasure.git

--- a/c_src/cmake/FindJerasure.cmake
+++ b/c_src/cmake/FindJerasure.cmake
@@ -8,6 +8,14 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
 endif()
 
+if (APPLE)
+  execute_process(COMMAND
+    xcrun --show-sdk-path
+    OUTPUT_VARIABLE APPLE_SDK_ROOT
+    )
+  set(GF_APPLE_ENV "SDKROOT=${APPLE_SDK_ROOT}")
+endif()
+
 ExternalProject_Add(jerasure
   PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/jerasure
   GIT_REPOSITORY    http://github.com/ceph/jerasure.git
@@ -23,7 +31,8 @@ ExternalProject_Add(jerasure
                     CC=${CMAKE_C_COMPILER}
                     "CFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
                     LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib
-  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j
+                    ${GF_APPLE_ENV}
+  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j ${GF_APPLE_ENV}
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libJerasure.a
   INSTALL_COMMAND   ${CMAKE_BUILD_TOOL} install
   )

--- a/c_src/cmake/FindJerasure.cmake
+++ b/c_src/cmake/FindJerasure.cmake
@@ -23,9 +23,9 @@ ExternalProject_Add(jerasure
                     CC=${CMAKE_C_COMPILER}
                     "CFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
                     LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/lib
-  BUILD_COMMAND     make -j
+  BUILD_COMMAND     ${CMAKE_BUILD_TOOL} -j
   BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/lib/libJerasure.a
-  INSTALL_COMMAND   make install
+  INSTALL_COMMAND   ${CMAKE_BUILD_TOOL} install
   )
 ExternalProject_Add_StepDependencies(jerasure build gf-complete)
 


### PR DESCRIPTION
This project depends on GNUMake, which may not be called `make` on
all systems. Use the more portable `CMAKE_BUILD_TOOL` variable instead.